### PR TITLE
v1.3.11 Added tree option for import_biom()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: phyloseq
-Version: 1.3.10
+Version: 1.3.11
 Date: 2013-01-31
 Title: Handling and analysis of high-throughput microbiome
     census data.

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -1424,12 +1424,29 @@ export_env_file <- function(physeq, file="", writeTree=TRUE, return=FALSE){
 #'
 #' \url{http://biom-format.org/} 
 #'
-#' @usage import_biom(BIOMfilename, parseFunction=parse_taxonomy_default, parallel=FALSE, version=0.9)
+#' @usage import_biom(BIOMfilename, tree=NULL, parseFunction=parse_taxonomy_default, parallel=FALSE, version=0.9, ...)
 #'
 #' @param BIOMfilename (Required). A character string indicating the 
 #'  file location of the BIOM formatted file. This is a JSON formatted file,
 #'  specific to biological datasets, as described in 
 #'  \url{http://www.qiime.org/svn_documentation/documentation/biom_format.html}{the biom-format home page}.
+#'  In principle, this file should include you OTU abundance data (OTU table),
+#'  your taxonomic classification data (taxonomy table), as well as your
+#'  sample data, for instance what might be in your ``sample map'' in QIIME.
+#'  A phylogenetic tree is not yet supported by biom-format, and so is a
+#'  separate argument here. If, for some reason, your biom-format file is
+#'  missing one of these mentioned data types but you have it in a separate file,
+#'  you can first import the data that is in the biom file using this function,
+#'  \code{import_biom}, and then ``merge'' the remaining data after you have
+#'  imported with other tools using the relatively general-purpose data
+#'  merging function called \code{\link{merge_phyloseq}}.
+#'
+#' @param tree (Optional). Character string or ``phylo'' class. 
+#'  A file path to the phylogenetic tree file associated
+#'  with the data in the \code{BIOMfilename}, or an already-imported version
+#'  of that phylogenetic tree as a phylo object.
+#'  Import of the tree will be attempted using \code{\link{read_tree}},
+#'  and additional import parameters for that function can be supplied (see below).
 #' 
 #' @param parseFunction (Optional). A function. It must be a function that
 #'  takes as its first argument a character vector of taxonomic rank labels
@@ -1468,9 +1485,16 @@ export_env_file <- function(physeq, file="", writeTree=TRUE, return=FALSE){
 #'  by adjusting the version value. Default is \code{0.9}. Not implemented.
 #'  Has no effect (yet).
 #'
+#' @param ... Additional parameters passed on to \code{\link{read_tree}}.
+#'
 #' @return A \code{\link{phyloseq-class}} object.
 #'
-#' @seealso \code{\link{import}}, \code{\link{import_qiime}}
+#' @seealso
+#' \code{\link{import}}
+#'
+#' \code{\link{import_qiime}}
+#'
+#' \code{\link{read_tree}}
 #'
 #' @references \url{http://www.qiime.org/svn_documentation/documentation/biom_format.html}{biom-format}
 #'
@@ -1489,7 +1513,7 @@ export_env_file <- function(physeq, file="", writeTree=TRUE, return=FALSE){
 #' # library("doParallel")
 #' # registerDoParallel(cores=6)
 #' # import_biom("my/file/path/file.biom", parseFunction=parse_taxonomy_greengenes, parallel=TRUE)
-import_biom <- function(BIOMfilename, parseFunction=parse_taxonomy_default, parallel=FALSE, version=0.9){
+import_biom <- function(BIOMfilename, tree=NULL, parseFunction=parse_taxonomy_default, parallel=FALSE, version=0.9, ...){
 	
 	# Read the data
 	x = fromJSON(BIOMfilename)
@@ -1546,11 +1570,24 @@ import_biom <- function(BIOMfilename, parseFunction=parse_taxonomy_default, para
 		rownames(sam_data) <- sapply(x$columns, function(i){i$id})
 		sam_data <- sample_data(sam_data)
 	}
+
+	########################################
+	# Tree data
+	########################################
+	if( !is.null(tree) ){
+		# If tree is already a tree, do nothing but explain to user
+		if( identical(class(tree)[1], "phylo") ){
+			cat("tree is already phylo-class, will be included")
+		} else {
+			cat("Attempting to import phylogenetic tree from the file-path you provided as tree, using function: read_tree")
+			tree = read_tree(tree, ...)
+		}
+	}
 	
 	########################################
 	# Put together into a phyloseq object
 	########################################
-	return( phyloseq(otutab, tax_table, sam_data) )
+	return( phyloseq(otutab, tax_table, sam_data, tree) )
 
 }
 ################################################################################

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -17,6 +17,14 @@ phyloseq
 * Lots of documentation updates.
 * Lots and lots of fixes and improvements.
 
+phyloseq 1.3.11
+===========
+- Added tree option for import_biom() importer so that users can avoid
+  using merge_phyloseq() if their files are otherwise standard vanilla
+- Address Issue 169 and 167
+https://github.com/joey711/phyloseq/issues/169
+https://github.com/joey711/phyloseq/issues/167
+
 phyloseq 1.3.10
 ===========
 - Added support for Shannon/Simpson alpha-diversity indices in plot_richness

--- a/man/import_biom.Rd
+++ b/man/import_biom.Rd
@@ -2,9 +2,9 @@
 \alias{import_biom}
 \title{Import phyloseq data from biom-format file}
 \usage{
-  import_biom(BIOMfilename,
+  import_biom(BIOMfilename, tree=NULL,
   parseFunction=parse_taxonomy_default, parallel=FALSE,
-  version=0.9)
+  version=0.9, ...)
 }
 \arguments{
   \item{BIOMfilename}{(Required). A character string
@@ -12,7 +12,29 @@
   This is a JSON formatted file, specific to biological
   datasets, as described in
   \url{http://www.qiime.org/svn_documentation/documentation/biom_format.html}{the
-  biom-format home page}.}
+  biom-format home page}. In principle, this file should
+  include you OTU abundance data (OTU table), your
+  taxonomic classification data (taxonomy table), as well
+  as your sample data, for instance what might be in your
+  ``sample map'' in QIIME. A phylogenetic tree is not yet
+  supported by biom-format, and so is a separate argument
+  here. If, for some reason, your biom-format file is
+  missing one of these mentioned data types but you have it
+  in a separate file, you can first import the data that is
+  in the biom file using this function, \code{import_biom},
+  and then ``merge'' the remaining data after you have
+  imported with other tools using the relatively
+  general-purpose data merging function called
+  \code{\link{merge_phyloseq}}.}
+
+  \item{tree}{(Optional). Character string or ``phylo''
+  class. A file path to the phylogenetic tree file
+  associated with the data in the \code{BIOMfilename}, or
+  an already-imported version of that phylogenetic tree as
+  a phylo object. Import of the tree will be attempted
+  using \code{\link{read_tree}}, and additional import
+  parameters for that function can be supplied (see
+  below).}
 
   \item{parseFunction}{(Optional). A function. It must be a
   function that takes as its first argument a character
@@ -58,6 +80,9 @@
   version-specific importers will be available by adjusting
   the version value. Default is \code{0.9}. Not
   implemented. Has no effect (yet).}
+
+  \item{...}{Additional parameters passed on to
+  \code{\link{read_tree}}.}
 }
 \value{
   A \code{\link{phyloseq-class}} object.
@@ -93,6 +118,10 @@ import_biom(rich_sparse_biom, parseFunction=parse_taxonomy_greengenes)
   \url{http://www.qiime.org/svn_documentation/documentation/biom_format.html}{biom-format}
 }
 \seealso{
-  \code{\link{import}}, \code{\link{import_qiime}}
+  \code{\link{import}}
+
+  \code{\link{import_qiime}}
+
+  \code{\link{read_tree}}
 }
 


### PR DESCRIPTION
# phyloseq 1.3.11
- Added tree option for import_biom() importer so that users can avoid
  using merge_phyloseq() if their files are otherwise standard vanilla
- Address Issue 169 and 167
  https://github.com/joey711/phyloseq/issues/169
  https://github.com/joey711/phyloseq/issues/167
