### PR TITLE
v1.3.12 fixed a parsing issue for QIIME-produced .biom files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phyloseq
-Version: 1.3.11
-Date: 2013-01-31
+Version: 1.3.12
+Date: 2013-02-04
 Title: Handling and analysis of high-throughput microbiome
     census data.
 Description: phyloseq provides a set of classes and tools

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -1655,6 +1655,10 @@ import_biom <- function(BIOMfilename, tree=NULL, parseFunction=parse_taxonomy_de
 #'  taxvec2 = c("Root;k__Bacteria;p__Firmicutes;c__Bacilli;o__Bacillales;f__Staphylococcaceae")
 #'  parse_taxonomy_qiime(taxvec2)
 parse_taxonomy_default = function(char.vec){
+	# Remove any leading empty space
+	char.vec = gsub("^[[:space:]]{1,}", "", char.vec)
+	# Remove any trailing space
+	char.vec = gsub("[[:space:]]{1,}$", "", char.vec)
 	if( length(char.vec) > 0 ){
 		# Add dummy element (rank) name
 		names(char.vec) = paste("Rank", 1:length(char.vec), sep="")

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -17,6 +17,17 @@ phyloseq
 * Lots of documentation updates.
 * Lots and lots of fixes and improvements.
 
+phyloseq 1.3.12
+===========
+- Fixed a parsing issue for some QIIME-produced .biom files
+  that had leading space characters. Issue further described at
+https://github.com/joey711/phyloseq/issues/171
+  Fixed such that any number of leading/lagging space characters
+  are removed from taxonomic classification entries
+
+- Fixed build issue on some windows machines derived from problem
+  with figure files having colons in the filename.
+
 phyloseq 1.3.11
 ===========
 - Added tree option for import_biom() importer so that users can avoid

--- a/inst/doc/phyloseq_analysis.Rnw
+++ b/inst/doc/phyloseq_analysis.Rnw
@@ -46,7 +46,7 @@
 \begin{document}
 \SweaveOpts{concordance=TRUE}
 
-\title{ Vignette for phyloseq: A Bioconductor package for handling and analysis of high-throughput phylogenetic sequence data }
+\title{ Vignette for phyloseq: A Bioconductor package for handling and analysis of high-throughput microbiome census data }
 
 \author{Paul J. M{c}Murdie$^*$ and Susan Holmes\\
 Statistics Department, Stanford University,\\
@@ -173,7 +173,7 @@ And now we will create the tree graphic form this subset of \code{GlobalPatterns
 \setkeys{Gin}{width=0.99\textwidth}
 \begin{figure}[htbp]
 \centering
-<<GP:chl:tree, fig=TRUE, width=15, height=7, message=FALSE, warning=FALSE>>=
+<<GP-chl-tree, fig=TRUE, width=15, height=7, message=FALSE, warning=FALSE>>=
 plot_tree(GP.chl, color="SampleType", shape="Family", label.tips="Genus", size="abundance")
 @
 \caption{Phylogenetic tree representation of the Chlamydiae species in the microbiome samples of the ``Global Patterns'' dataset~\cite{Caporaso15032011}.}

--- a/inst/tests/test-IO.R
+++ b/inst/tests/test-IO.R
@@ -124,6 +124,11 @@ test_that("Taxonomy vector parsing functions behave as expected", {
 	chvec4 = c("Root", "k__Bacteria", "Firmicutes", "c__Bacilli",
 		"o__Bacillales", "Staphylococcaceae", "z__mistake")
 
+	# Even more terrible example, where leading or trailing space characters included
+	# (the exact weirdnes of chvec4, compounded by leading and/or trailing space characters)
+	chvec5 = c("  Root \n ", " k__Bacteria", "  Firmicutes", " c__Bacilli   ",
+		"o__Bacillales  ", "Staphylococcaceae ", "\t z__mistake \t\n")		
+
 	# This should give a warning because there were no greengenes prefixes
 	expect_warning(t1 <- parse_taxonomy_greengenes(chvec1))
 	# And output from previous call, t1, should be identical to default
@@ -145,7 +150,14 @@ test_that("Taxonomy vector parsing functions behave as expected", {
 	# Check that everything given dummy rank in default parse.
 	chvec4ranks = names(parse_taxonomy_default(chvec4))
 	expect_that(grep("Rank", chvec4ranks, fixed=TRUE), is_equivalent_to(1:7))
-
+	
+	# chvec4 and chvec5 result in identical vectors.
+	expect_that(parse_taxonomy_default(chvec4), is_identical_to(parse_taxonomy_default(chvec5)))
+	expect_that(parse_taxonomy_greengenes(chvec4), is_identical_to(parse_taxonomy_greengenes(chvec5)))	
+	
+	# The names of chvec5, greengenes parsed, should be...
+	correct5names = c("Rank1", "Kingdom", "Rank3", "Class", "Order", "Rank6", "Rank7")
+	expect_that(names(parse_taxonomy_greengenes(chvec5)), is_identical_to(correct5names))
 })
 
 ################################################################################


### PR DESCRIPTION
# phyloseq 1.3.12
- Fixed a parsing issue for some QIIME-produced .biom files
  that had leading space characters. Issue further described at
  https://github.com/joey711/phyloseq/issues/171
  Fixed such that any number of leading/lagging space characters
  are removed from taxonomic classification entries
- Fixed build issue on some windows machines derived from problem
  with figure files having colons in the filename.
