### PR TITLE
v1.5.15 fixed taxonomy import bug in revised import_biom()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phyloseq
-Version: 1.5.14
-Date: 2013-05-12
+Version: 1.5.15
+Date: 2013-05-13
 Title: Handling and analysis of high-throughput microbiome
     census data.
 Description: phyloseq provides a set of classes and tools

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -1652,24 +1652,15 @@ import_biom <- function(BIOMfilename,
 	# Taxonomy Table
 	########################################
 	# Need to check if taxonomy information is empty (minimal BIOM file)
-	if( is.null(observation_metadata(x)) ){
-		taxtab <- NULL
-	} else {
-    taxdf = observation_metadata(x)
-    if( any(grep("taxonomy", colnames(taxdf))) ){
-      # Expectation is that for biom files, taxonomy data
-      # will be labeled as such. The format leaves open 
-      # the possibility of other forms of OTU metadata
-      # that are not really supported... although might
-      # still work fine. Just character matrix, after all.
-      taxtab = tax_table(t(apply(taxdf, 1, parseFunction)))
-    }
-    # 		# parse once each character vector, save as a list
-    # 		taxlist = lapply(x$rows, function(i){
-    # 			parseFunction(i$metadata$taxonomy)
-    # 		})
-    # 		names(taxlist) = sapply(x$rows, function(i){i$id})
-    # 		tax_table = build_tax_table(taxlist)
+	if(  all( sapply(sapply(x$rows, function(i){i$metadata}), is.null) )  ){
+	  tax_table <- NULL
+  } else {
+    # parse once each character vector, save as a list
+    taxlist = lapply(x$rows, function(i){
+      parseFunction(i$metadata$taxonomy)
+    })
+    names(taxlist) = sapply(x$rows, function(i){i$id})
+    taxtab = build_tax_table(taxlist)
 	}
 	argumentlist <- c(argumentlist, list(taxtab))
 	

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -20,6 +20,10 @@ phyloseq
 * Lots of documentation updates.
 * Lots and lots of fixes and improvements.
 
+phyloseq 1.5.13-15 - build improvements, changed dependencies
+===========
+
+
 phyloseq 1.5.11-12 - major feature: interface to microbio.me/qiime data repo
 ===========
 Now possible to directly download, unpack, import multi-component data


### PR DESCRIPTION
taxonomy import issue from updated `import_biom` now depending on [the biom package](http://cran.r-project.org/web/packages/biom/).

This has been fixed, and uses once again the much more robust taxonomy import approach also used in the `import_qiime` function.
