### PR TITLE
v1.5.16 improvements for `rarefy_even_depth()` function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phyloseq
 Version: 1.5.16
-Date: 2013-05-20
+Date: 2013-05-21
 Title: Handling and analysis of high-throughput microbiome
     census data.
 Description: phyloseq provides a set of classes and tools
@@ -35,7 +35,8 @@ Enhances: doParallel (>= 1.0.1)
 biocViews: Clustering, Classification, MultipleComparisons,
     QualityControl, GeneticVariability,
     HighThroughputSequencing
-URL: http://joey711.github.io/phyloseq/
+URL: http://dx.plos.org/10.1371/journal.pone.0061217,
+    http://joey711.github.io/phyloseq/
 BugReports: https://github.com/joey711/phyloseq/issues
 Collate:
     'allClasses.R'

--- a/R/transform_filter-methods.R
+++ b/R/transform_filter-methods.R
@@ -18,12 +18,10 @@
 #' but it is actually a single random sample-wise subsampling procedure.
 #' The original rarefaction procedure includes many
 #' random subsampling iterations at increasing depth as a means to
-#' infer richness/alpha-diversity
+#' infer richness/alpha-diversity based on apparent convergence.
 #'
 #' Make sure to use \code{\link{set.seed}} for exactly-reproducible results
 #' of the random subsampling. 
-#'
-#' @usage rarefy_even_depth(physeq, sample.size=min(sample_sums(physeq)))
 #'
 #' @param physeq (Required). A \code{\link{phyloseq-class}} object that you
 #'  want to trim/filter.
@@ -32,6 +30,14 @@
 #'  of reads being simulated, also known as the depth,
 #'  and also equal to each value returned by \code{\link{sample_sums}}
 #'  on the output. 
+#'  
+#' @param rngseed (Optional). A single integer value passed to 
+#'  \code{\link{set.seed}}, which is used to fix a seed for reproducibly
+#'  random number generation (in this case, reproducibly random subsampling).
+#'  The default value is \code{711}. 
+#'  If set to \code{FALSE}, then no fiddling with the RNG seed is performed,
+#'  and it is up to the user to appropriately call \code{\link{set.seed}}
+#'  beforehand to achieve reproducible results.
 #'
 #' @return An object of class \code{phyloseq}. 
 #' Only the \code{otu_table} component is modified.
@@ -44,19 +50,20 @@
 #' @export
 #'
 #' @examples
-#' set.seed(711)
 #' # Test with esophagus dataset
 #' data("esophagus")
-#' eso <- rarefy_even_depth(esophagus)
-#' plot(as(otu_table(eso), "vector"), as(otu_table(esophagus), "vector"))
-#' UniFrac(eso); UniFrac(esophagus)
+#' eso  = rarefy_even_depth(esophagus)
+#' eso0 = prune_taxa(taxa_names(eso), esophagus) 
+#' plot(as(otu_table(eso), "vector"), as(otu_table(eso0), "vector"))
+#' UniFrac(eso); UniFrac(eso0); UniFrac(esophagus)
 #' # Test with GlobalPatterns dataset
 #' data("GlobalPatterns")
 #' GP.chl <- subset_taxa(GlobalPatterns, Phylum=="Chlamydiae")
 #' # remove the samples that have less than 20 total reads from Chlamydiae
 #' GP.chl <- prune_samples(names(which(sample_sums(GP.chl)>=20)), GP.chl)
 #' # # (p <- plot_tree(GP.chl, color="SampleType", shape="Family", label.tips="Genus", size="abundance"))
-#' GP.chl.r <- rarefy_even_depth(GP.chl)
+#' GP.chl.r = rarefy_even_depth(GP.chl)
+#' GP.chl = prune_taxa(taxa_names(GP.chl.r), GP.chl)
 #' plot(as(otu_table(GP.chl.r), "vector"), as(otu_table(GP.chl), "vector"))
 #' # Try ordination of GP.chl and GP.chl.r (default distance is unweighted UniFrac)
 #' plot_ordination(GP.chl, ordinate(GP.chl, "MDS"), color="SampleType") #+ geom_point(size=5)
@@ -64,20 +71,26 @@
 rarefy_even_depth <- function(physeq, sample.size=min(sample_sums(physeq)),
 															rngseed=711){
 	
-	# Store the original seed arrived at before calling this function
-	orig_seed <- .Random.seed
-	# Now call the set.seed using the value expected in phyloseq
-	set.seed(rngseed)
-	# Print to screen this value
-	cat("`set.seed(", rngseed, 
-			")` was used to initialize repeatable random subsampling",
-			sep="", fill=TRUE)
-	cat("Please record this for your records so others can reproduce.", fill=TRUE)
-	cat("Try `set.seed(", rngseed,"); .Random.seed` for the full vector", sep="", fill=TRUE)
+	if( as(rngseed, "logical") ){
+		# Now call the set.seed using the value expected in phyloseq
+		set.seed(rngseed)
+		# Print to screen this value
+		cat("`set.seed(", rngseed, 
+				")` was used to initialize repeatable random subsampling.",
+				sep="", fill=TRUE)
+		cat("Please record this for your records so others can reproduce.", fill=TRUE)
+		cat("Try `set.seed(", rngseed,"); .Random.seed` for the full vector", sep="", fill=TRUE)		
+		cat("...", fill=TRUE)
+	} else {
+		cat("You set `rngseed` to FALSE. Make sure you've set & recorded",
+				" the random seed of your session for reproducibility.",
+				"See `set.seed()`", fill=TRUE)
+		cat("...", fill=TRUE)
+	}
 	
 	# Make sure sample.size is of length 1.
 	if( length(sample.size) > 1 ){
-		warning("`sample.size` had more than one value. Using only the first.")
+		warning("`sample.size` had more than one value. Using only the first. \n ... \n")
 		sample.size <- sample.size[1]	
 	}
 	
@@ -89,9 +102,11 @@ rarefy_even_depth <- function(physeq, sample.size=min(sample_sums(physeq)),
 	# that have fewer reads than `sample.size`
 	if( min(sample_sums(physeq)) < sample.size ){
 		rmsamples = sample_names(physeq)[sample_sums(physeq) < sample.size]
-		cat("Removing the following samples,", 
-				"because they contained fewer reads than `sample.size`:", fill=TRUE)
-		cat(rmsamples, sep="\t", fill=TRUE)
+		cat(length(rmsamples), " samples removed",
+				"because they contained fewer reads than `sample.size`.", fill=TRUE)
+		cat("Up to first five removed samples are: \n")
+		cat(rmsamples[1:min(5, length(rmsamples))], sep="\t", fill=TRUE)
+		cat("...", fill=TRUE)
 		# Now done with notifying user of pruning, actually prune.
 		physeq = prune_samples(setdiff(sample_names(physeq), rmsamples), physeq)
 	}
@@ -110,14 +125,18 @@ rarefy_even_depth <- function(physeq, sample.size=min(sample_sums(physeq)),
   # 2. Cut empty OTUs
 	rmtaxa = taxa_names(newsub)[taxa_sums(newsub) <= 0]
   if( length(rmtaxa) > 0 ){
-    cat("The following OTUs are being removed because they are no longer \n",
-        "present in any sample after subsampling:\n")
-    cat(rmtaxa, sep="\t", fill=TRUE)
+    cat(length(rmtaxa), "OTUs were removed because they are no longer \n",
+        "present in any sample after random subsampling\n")
+    cat("...", fill=TRUE)
+    #cat(rmtaxa[1:min(5, length(rmtaxa))], sep="\t", fill=TRUE)
     newsub = prune_taxa(setdiff(taxa_names(newsub), rmtaxa), newsub)
   }
-	# Reset set.seed to unitialized state
-	set.seed(NULL)
-	cat("Finished. `set.seed(NULL)` called, resetting seed to unitialized state.", fill=TRUE)
+	if( as(rngseed, "logical") ){
+		# Reset set.seed to unitialized state
+		set.seed(NULL)
+		cat("Finished. `set.seed(NULL)` called, ", 
+				"resetting RNG seed to unitialized state.", fill=TRUE)
+	}
 	# return subsampled phyloseq object
 	return(newsub)
 }

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -20,9 +20,20 @@ phyloseq
 * Lots of documentation updates.
 * Lots and lots of fixes and improvements.
 
+
+phyloseq 1.5.16 - rarefy_even_depth improvements
+===========
+User-side convenience upgrades to rarefy_even_depth() behavior.
+
+- More user feedback about process.
+- New argument for setting RNG seed, with a default value (reproducible by default).
+- Reports the RNG seed being used for random subsampling, encouraging users to record this for reproducibility.
+- Trims empty samples/OTUs automatically, and reports this to standard out.
+
+
 phyloseq 1.5.13-15 - build improvements, changed dependencies
 ===========
-
+Shifted RJSONIO dependency to the new "biom" package in CRAN
 
 phyloseq 1.5.11-12 - major feature: interface to microbio.me/qiime data repo
 ===========

--- a/inst/tests/test-rarefy.R
+++ b/inst/tests/test-rarefy.R
@@ -1,0 +1,39 @@
+################################################################################
+# Use testthat to test phyloseq transformation functions/methods
+################################################################################
+library("phyloseq"); library("testthat")
+# # # # TESTS!
+################################################################################
+# rarefy_even_depth
+################################################################################
+data("GlobalPatterns")
+set.seed(711) # The random seed for randomly selecting subset of OTUs
+randoOTUs = sample(taxa_names(GlobalPatterns), 100, FALSE)
+GP100 = prune_taxa(randoOTUs, GlobalPatterns)
+# The default rng seed is being implied in this call (also 711)
+rGP = rarefy_even_depth(GP100, 1000)
+################################################################################
+# Test that specific OTUs and samples were removed
+################################################################################
+test_that("Test that empty OTUs and samples were automatically pruned", {
+	rmOTU = setdiff(taxa_names(GP100), taxa_names(rGP))
+	expect_equal(length(rmOTU), 20L)
+	expect_equal(rmOTU[1:5], c("534601", "408325", "325564", "8112", "571917"))
+	expect_true(taxa_names(GP100)[taxa_sums(GP100) <= 0] %in% rmOTU)
+	expect_true(all(taxa_sums(rGP) > 0))
+	rmsam = setdiff(sample_names(GP100), sample_names(rGP))
+	expect_equal(length(rmsam), 12L)
+	expect_equal(rmsam[1:5], c("M11Fcsw", "M31Tong", "M11Tong", "NP2", "TRRsed1"))
+	expect_true(all(sample_sums(rGP) > 0))
+})
+################################################################################
+# Test specific values. Should be reproducible, and you set the seed.
+################################################################################
+test_that("Test values", {
+	expect_equal(as(otu_table(rGP)[1, 3:10], "vector"), rep(0, 8))
+	expect_equal(as(otu_table(rGP)[2, 1:10], "vector"), c(rep(0, 9), 1))
+	expect_equal(as(otu_table(rGP)[3, 8:12], "vector"), c(883, 962, 59, 9, 29))
+	expect_equal(as(otu_table(rGP)[70:78, 4], "vector"),
+							 c(707, 3, 0, 2, 0, 8, 157, 2, 0))
+})
+################################################################################

--- a/man/rarefy_even_depth.Rd
+++ b/man/rarefy_even_depth.Rd
@@ -2,8 +2,8 @@
 \alias{rarefy_even_depth}
 \title{Perform a random subsampling of an OTU table to a level of even depth.}
 \usage{
-  rarefy_even_depth(physeq,
-  sample.size=min(sample_sums(physeq)))
+  rarefy_even_depth(physeq, sample.size =
+  min(sample_sums(physeq)), rngseed = 711)
 }
 \arguments{
   \item{physeq}{(Required). A \code{\link{phyloseq-class}}
@@ -13,6 +13,15 @@
   equal to the number of reads being simulated, also known
   as the depth, and also equal to each value returned by
   \code{\link{sample_sums}} on the output.}
+
+  \item{rngseed}{(Optional). A single integer value passed
+  to \code{\link{set.seed}}, which is used to fix a seed
+  for reproducibly random number generation (in this case,
+  reproducibly random subsampling). The default value is
+  \code{711}. If set to \code{FALSE}, then no fiddling with
+  the RNG seed is performed, and it is up to the user to
+  appropriately call \code{\link{set.seed}} beforehand to
+  achieve reproducible results.}
 }
 \value{
   An object of class \code{phyloseq}. Only the
@@ -33,25 +42,27 @@
   single random sample-wise subsampling procedure. The
   original rarefaction procedure includes many random
   subsampling iterations at increasing depth as a means to
-  infer richness/alpha-diversity
+  infer richness/alpha-diversity based on apparent
+  convergence.
 
   Make sure to use \code{\link{set.seed}} for
   exactly-reproducible results of the random subsampling.
 }
 \examples{
-set.seed(711)
 # Test with esophagus dataset
 data("esophagus")
-eso <- rarefy_even_depth(esophagus)
-plot(as(otu_table(eso), "vector"), as(otu_table(esophagus), "vector"))
-UniFrac(eso); UniFrac(esophagus)
+eso  = rarefy_even_depth(esophagus)
+eso0 = prune_taxa(taxa_names(eso), esophagus)
+plot(as(otu_table(eso), "vector"), as(otu_table(eso0), "vector"))
+UniFrac(eso); UniFrac(eso0); UniFrac(esophagus)
 # Test with GlobalPatterns dataset
 data("GlobalPatterns")
 GP.chl <- subset_taxa(GlobalPatterns, Phylum=="Chlamydiae")
 # remove the samples that have less than 20 total reads from Chlamydiae
 GP.chl <- prune_samples(names(which(sample_sums(GP.chl)>=20)), GP.chl)
 # # (p <- plot_tree(GP.chl, color="SampleType", shape="Family", label.tips="Genus", size="abundance"))
-GP.chl.r <- rarefy_even_depth(GP.chl)
+GP.chl.r = rarefy_even_depth(GP.chl)
+GP.chl = prune_taxa(taxa_names(GP.chl.r), GP.chl)
 plot(as(otu_table(GP.chl.r), "vector"), as(otu_table(GP.chl), "vector"))
 # Try ordination of GP.chl and GP.chl.r (default distance is unweighted UniFrac)
 plot_ordination(GP.chl, ordinate(GP.chl, "MDS"), color="SampleType") #+ geom_point(size=5)


### PR DESCRIPTION
Satisfies Issue 212
https://github.com/joey711/phyloseq/issues/212
# phyloseq 1.5.16 - rarefy_even_depth improvements

User-side convenience upgrades to rarefy_even_depth() behavior.
- More user feedback about process.
- New argument for setting RNG seed, with a default value (reproducible by default).
- Reports the RNG seed being used for random subsampling, encouraging users to record this for reproducibility.
- Trims empty samples/OTUs automatically, and reports this to standard out.
