### PR TITLE
v1.5.22 - Fix minor bug in `import_mothur`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: phyloseq
-Version: 1.5.21
-Date: 2013-08-12
+Version: 1.5.22
+Date: 2013-08-30
 Title: Handling and analysis of high-throughput microbiome
     census data.
 Description: phyloseq provides a set of classes and tools

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -1196,6 +1196,8 @@ import_mothur_otu_table <- function(mothur_list_file, mothur_group_file, cutoff=
 	
 	otulist       <- import_mothur_otulist(mothur_list_file, cutoff)
 	mothur_groups <- import_mothur_groups(mothur_group_file)
+  # Coerce the sample names column of the group hash table to a factor
+	mothur_groups[, 2] <- factor(mothur_groups[, 2])
 	
 	# Initialize abundance matrix
 	mothur_otu_table <- matrix(0, nrow=length(otulist), ncol=length(levels(mothur_groups[, 2])))

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -20,6 +20,11 @@ phyloseq
 * Lots of documentation updates.
 * Lots and lots of fixes and improvements.
 
+phyloseq 1.5.22 - Fix minor bug in `import_mothur`
+===========
+- Bug occurs only when sample names are pure integers. One line fix.
+- This addresses [Issue 242](https://github.com/joey711/phyloseq/issues/242) 
+
 phyloseq 1.5.21 - `plot_richness` / `estimate_richness` updates
 ===========
 -- Additional alpha-diversity measures added to both functions.


### PR DESCRIPTION
https://github.com/joey711/phyloseq/issues/242
# phyloseq 1.5.22 - Fix minor bug in `import_mothur`
- Bug occurs only when sample names are pure integers. One line fix.
- This addresses [Issue 242](https://github.com/joey711/phyloseq/issues/242)
