### PR TITLE
added plot_timeseries

### DIFF
--- a/R/plot-methods.R
+++ b/R/plot-methods.R
@@ -2783,5 +2783,51 @@ plot_clusgap = function(clusgap, title="Gap Statistic results"){
 	p = p + ggtitle(title)
 	return(p)
 }
+
+
 ################################################################################
 ################################################################################
+#' A flexible, informative timeseries plot for phyloseq data
+#'
+#' This function wraps \code{ggplot2} plotting, and returns a \code{ggplot2}
+#'  graphic object
+#' that can be saved or further modified with additional layers, options, etc.
+#' The main purpose of this function is to quickly and easily create informative
+#' summary graphics of the differences in taxa abundance between samples in
+#' an experiment.
+#'
+#' @usage plot_bar(physeq, x="Age", y="Abundance", color=NULL)
+#'
+#' @param physeq (Required). A \code{\link{phyloseq-class}}.
+#'
+#' @param x (Required). A character string.
+#' The variable which corresponds to time.
+#'
+#' @param y (Optional). A character string.
+#'  The variable in the melted-data that should be mapped to the y-axis.
+#'  By default this will be \code{"Abundance"}, in order to
+#'  quantitatively display the abundance values for each OTU/group.
+#'  However, alternative variables could be used instead,
+#'  producing a very different, though possibly still informative, plot.
+#'  See \code{\link{psmelt}}, \code{\link{melt}},
+#'  and \code{\link{ggplot}} for more details.
+#'
+#' @param  color(Optional). A character string. Indicates which sample variable
+#'  should be used to map to the color of the splines.
+#'  The default is \code{NULL}, resulting in a gray fill for all bar segments.
+#'
+#' @import ggplot2
+#' @export
+#'
+#' @examples
+#' data("enterotypes")
+#' glom <- tax_glom(enterotypes, taxrank='Genus')
+#' plot_timeseries(glom, y='Abundance', x='Age', color='Enterotype')
+#'
+plot_timeseries <- function(g, x=NULL, y=NULL, color=NULL) {
+  mdf <- psmelt(g)
+
+  p <- ggplot(mdf, aes_string(y='Abundance', x=x, color=color)) + geom_smooth()
+
+  return(p)
+}


### PR DESCRIPTION
I wrote a small function to plot relative abundance across a time variable using `geom_smooth`. The example is slow and the documentation needs a little work.

I use a similar function to this all the time and thought it would be a useful addition.

The function I typically use differs in that I plot a `geom_ribbon` with the standard error around the mean. I also discretize the time variable using `cut`. I would add this but I thought it would be better to stick to plain ggplot2 style plotting.

Let me know what you think. I can add more docs and create a better example.

EDIT: This is what the ribbon smoothing plot looks like.

![screen shot 2014-03-13 at 10 59 14 am](https://f.cloud.github.com/assets/115904/2410743/239095d4-aac0-11e3-9120-261aa75305da.png)
