### PR TITLE
1.9.1 psmelt bigfix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: phyloseq
-Version: 1.9.0
+Version: 1.9.1
 Date: 2014-04-18
 Title: Handling and analysis of high-throughput microbiome
     census data.
@@ -13,16 +13,16 @@ Author: Paul J. McMurdie <mcmurdie@stanford.edu>, Susan
 License: AGPL-3
 Imports:
     ade4 (>= 1.6.2),
-    ape (>= 3.0.8),
+    ape (>= 3.1.1),
     biom (>= 0.3.9),
     Biostrings (>= 2.28.0),
     cluster (>= 1.14.4),
-    data.table (>= 1.8.10),
-    DESeq2 (>= 1.0.19),
-    foreach (>= 1.4),
+    data.table (>= 1.9.2),
+    DESeq2 (>= 1.4.0),
+    foreach (>= 1.4.2),
     ggplot2 (>= 0.9.3.1),
     igraph (>= 0.6.5.2),
-    methods (>= 3.0.0),
+    methods (>= 3.1.0),
     multtest (>= 2.16.0),
     plyr (>= 1.8),
     reshape2 (>= 1.2.2),

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,3 +1,12 @@
+CHANGES IN VERSION 1.9.1
+-------------------------
+
+BUG FIXES
+
+	- Bug in `psmelt` causing unnecessary error for phyloseq datasets with empty components.
+
+	- Solves Issue 319: https://github.com/joey711/phyloseq/issues/313
+
 CHANGES IN VERSION 1.7.24
 -------------------------
 


### PR DESCRIPTION
## CHANGES IN VERSION 1.9.1

BUG FIXES

```
- Bug in `psmelt` causing unnecessary error for phyloseq datasets with
```

empty components.

```
- Solves Issue 319: https://github.com/joey711/phyloseq/issues/319
```
