### PR TITLE
use wascores from vegan to get species scores for biplot when ordination...

### DIFF
--- a/R/plot-methods.R
+++ b/R/plot-methods.R
@@ -899,8 +899,13 @@ plot_ordination = function(physeq, ordination, type="samples", axes=c(1, 2),
   siteDF = NULL
   specDF = NULL
   if( type %in% c("species", "split", "biplot") ){
-    specDF <- data.frame(scores(ordination, choices=axes, display="species"), 
-                         stringsAsFactors=FALSE)
+    if( class(ordination) == "pcoa" ){
+      # use wascores to get taxa weighted averages for the given axes
+      specDF <- wascores(ordination$vectors[,axes], t(otu_table(physeq)))
+    } else{
+      specDF <- data.frame(scores(ordination, choices=axes, display="species"), 
+                           stringsAsFactors=FALSE)
+    }
     if( length(specDF) < 2 ){
       specDF <- NULL
       warning("The `scores` method failed to acquire taxa/OTU/species coordinates \n",


### PR DESCRIPTION
... class is 'pcoa'.

When ordination class is "pcoa" and `plot_ordination` type is "taxa" or "biplot" `plot_ordination` just returns the sites scores for the given "axes" because the Vegan `scores` function doesn't support the "pcoa" ordination object.  The class of the ordination object can be tested for and subsequently the Vegan `wascores` function can be used to calculate weighted averages of taxa for given "axes" if the class is "pcoa". Works with the current `plot_ordination` arguments/interface.

This is a belated pull request based on a quick discussion we had at your ASM poster.
