### PR TITLE
Preserve factor level order when creating sample_data

### DIFF
--- a/R/sampleData-class.R
+++ b/R/sampleData-class.R
@@ -96,8 +96,8 @@ reconcile_categories <- function(DFSM){
 	#factor_cols <- names(variable_classes[variable_classes %in% c("factor", "character")])
 	factor_cols = which(sapply(DF, inherits, what="factor"))
 	for( j in factor_cols){
-        l = levels(DF[, j])
-        DF[, j] <- factor(DF[, j], l[l %in% DF[, j]])
+		l = levels(DF[, j])
+		DF[, j] <- factor(DF[, j], l[l %in% DF[, j]])
 	}
 	return(DF)
 }


### PR DESCRIPTION
I just started using phyloseq and it is great! However, I was slightly annoyed that sample_data() changed the ordering of the factor levels. These play important role in drawing plots with ggplot2, so I decided to create a quick fix for the problem. There I drop unused levels but the order of remaining ones stays the same.
