### PR TITLE
switched to droplevels 

### DIFF
--- a/R/sampleData-class.R
+++ b/R/sampleData-class.R
@@ -96,7 +96,8 @@ reconcile_categories <- function(DFSM){
 	#factor_cols <- names(variable_classes[variable_classes %in% c("factor", "character")])
 	factor_cols = which(sapply(DF, inherits, what="factor"))
 	for( j in factor_cols){
-		DF[, j] <- factor( as(DF[, j], "character") )
+		#DF[, j] <- factor( as(DF[, j], "character") )
+		DF[, j] <- droplevels(DF[, j])
 	}
 	return(DF)
 }


### PR DESCRIPTION
The reconcile_ categories was loosing the original factor level ordering. This can potentially cause confusion. I propose keeping the original order of the factor levels and modified the function accordingly. At minimum, there should be a function argument to allow keeping the original order.