### PR TITLE
Updated psmelt function to not break when package reshape is loaded

### DIFF
--- a/R/plot-methods.R
+++ b/R/plot-methods.R
@@ -1469,9 +1469,10 @@ psmelt = function(physeq){
   otutab = otu_table(physeq)
   if(!taxa_are_rows(otutab)){otutab <- t(otutab)}
   # Melt the OTU table: wide form to long form table
-  mdf = melt(as(otutab, "matrix"), value.name="Abundance")
+  mdf = melt(as(otutab, "matrix"))
   colnames(mdf)[1] <- "OTU"
   colnames(mdf)[2] <- "Sample"
+  colnames(mdf)[3] <- "Abundance"
   # Row and Col names are coerced to integer or factor if possible.
   # Do not want this. Coerce these to character.
   # e.g. `OTU` should always be discrete, even if OTU ID values can be coerced to integer

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -497,4 +497,12 @@ test_that("psmelt doesn't break when the number of taxa is 1", {
   expect_true(all(reqnames %in% names(df)))
   expect_equivalent(sum(df$Abundance, na.rm = TRUE), taxa_sums(GP1))
 })
+test_that("psmelt doesn't break when package reshape is loaded", {
+    data(GlobalPatterns)
+    library(reshape)
+    mdf1 <- psmelt(GlobalPatterns)
+    detach(package:reshape)
+    mdf2 <-psmelt(GlobalPatterns)
+    expect_equivalent(mdf1,mdf2)
+})
 ################################################################################


### PR DESCRIPTION
This is to fix the problem of psmelt failing if the user has loaded package reshape.  The function renames the "Abundance" column after melting rather than during the melt() call to be consistent with the syntax of melt() in reshape. 

This addresses the following logged issues:
https://github.com/joey711/phyloseq/issues/437
https://github.com/joey711/phyloseq/issues/444
https://github.com/joey711/phyloseq/issues/440
https://github.com/joey711/phyloseq/issues/484