### PR TITLE
fix an error related to merging of taxa on single-column taxonomy tables

### DIFF
--- a/R/merge-methods.R
+++ b/R/merge-methods.R
@@ -446,7 +446,12 @@ setMethod("merge_taxa", "taxonomyTable", function(x, eqtaxa, archetype=1L){
 	# # # Taxonomy is trivial in ranks after disagreement among merged taxa
 	# # # Make those values NA_character_
 	taxmerge  <- as(x, "matrix")[eqtaxa, ]
-	bad_ranks <- apply(taxmerge, 2, function(i){ length(unique(i)) != 1 })
+  
+	bad_ranks <- NULL
+  #single column tax-tables
+  if ( dim(as.matrix(taxmerge))[[2]] > 1){
+    bad_ranks <- apply(taxmerge, 2, function(i){ length(unique(i)) != 1 })
+  }
 	# Test if all taxonomies agree. If so, do nothing. Just continue to pruning.
 	if( any(bad_ranks) ){
 		# The col indices of the bad ranks


### PR DESCRIPTION
If you have a single column taxonomy table, the `merge_taxa` function throws an error (see below). I've attached a code that fixes it.  The error is due to code resolving issues in the tax table that do not apply for a single-column tax table. So I just check for the dimension before trying to run apply. There may be a cleaner way to do the same thing.

``` r
library(phyloseq)
data("GlobalPatterns")
GP = GlobalPatterns
tt <- tax_table(GP)
dim(tt)
[1] 19216     7

tax_table(GP) <- tax_table(tt[,1])
merge_taxa(GP,eqtaxa = 1:2)
 Show Traceback

 Rerun with Debug
 Error in apply(taxmerge, 2, function(i) { : 
  dim(X) must have a positive length 

```
