### PR TITLE
Added a SILVA parseFunction.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.Rproj
 *Rplots.pdf
 
+/.idea
+/.idea/**
+
 cache/*
 figure/*
 

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -1861,7 +1861,7 @@ import_biom <- function(BIOMfilename,
 #' These are provided as both example and default functions for
 #' parsing a character vector of taxonomic rank information for a single taxa.
 #' As default functions, these are intended for cases where the data adheres to
-#' the naming convention used by greengenes
+#' the naming convention used by greengenes and silva.
 #' (\url{http://greengenes.lbl.gov/cgi-bin/nph-index.cgi})
 #' or where the convention is unknown, respectively.
 #' To work, these functions -- and any similar custom function you may want to
@@ -1882,6 +1882,12 @@ import_biom <- function(BIOMfilename,
 #' to the appropriate taxonomic rank name used by greengenes
 #' (e.g. \code{"p__"} at the beginning of an element means that element is 
 #' the name of the phylum to which this OTU belongs).
+#' If you taxonomy data is based on SILVA, the \code{parse_taxonomy_silva} function
+#' clips the first 5 characters that identify rank, and uses these to name the
+#' corresponding element according to the appropriate taxonomic rank name used
+#' by SILVA (e.g. \code{"D_1__"} at the beginning of an element means that element
+#' is the name of the phylum to which this OTU belongs.
+#' Alternatively you can create your own function to parse this data.
 #' Most importantly, the expectations for these functions described above
 #' make them compatible to use during data import,
 #' specifcally the \code{\link{import_biom}} function, but 
@@ -1890,6 +1896,7 @@ import_biom <- function(BIOMfilename,
 #'
 #' @usage parse_taxonomy_default(char.vec)
 #' @usage parse_taxonomy_greengenes(char.vec)
+#' @usage parse_taxonomy_silva(char.vec)
 #' @usage parse_taxonomy_qiime(char.vec)
 #'
 #' @param char.vec (Required). A single character vector of taxonomic
@@ -1917,6 +1924,8 @@ import_biom <- function(BIOMfilename,
 #'  parse_taxonomy_greengenes(taxvec1)
 #'  taxvec2 = c("Root;k__Bacteria;p__Firmicutes;c__Bacilli;o__Bacillales;f__Staphylococcaceae")
 #'  parse_taxonomy_qiime(taxvec2)
+#' taxvec3 = c("D_0__Bacteria", "D_1__Firmicutes", "D_2__Bacilli", "D_3__Staphylococcaceae")
+#' parse_taxonomy_silva(taxvec3)
 parse_taxonomy_default = function(char.vec){
 	# Remove any leading empty space
 	char.vec = gsub("^[[:space:]]{1,}", "", char.vec)

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -1968,7 +1968,9 @@ parse_taxonomy_greengenes <- function(char.vec){
 	}
 	return(taxvec)
 }
-
+#' @rdname parseTaxonomy-functions
+#' @aliases parse_taxonomy_default
+#' @export
 parse_taxonomy_silva <- function(char.vec){
   # Use default to assign names to elements in case problem with greengenes prefix
   char.vec = parse_taxonomy_default(char.vec)
@@ -1977,7 +1979,7 @@ parse_taxonomy_silva <- function(char.vec){
     char.vec <- c(Rank1="D_0__Unassigned", Rank2="D_1__Unassigned", Rank3="D_2__Unassigned", Rank4="D_3__Unassigned",
                   Rank5="D_4__Unassigned", Rank6="D_5__Unassigned", Rank7="D_6__Unassigned")
   }
-  # Define the meaning of each prefix according to GreenGenes taxonomy
+  # Define the meaning of each prefix according to SILVA taxonomy
   Tranks = c(D_0="Kingdom", D_1="Phylum", D_2="Class", D_3="Order", D_4="Family", D_5="Genus", D_6="Species")
   # Check for prefix using regexp, warn if there were none. trim indices, ti
   ti = grep("[[:alpha:]]\\_[[:digit:]]{1}\\_\\_", char.vec)


### PR DESCRIPTION
Added a function to parse SILVA formatted taxonomy strings in the BIOM formatted files.

### Overview
- Added parse_silva_taxonomy function
  - Added comments and docstrings
  - Formats unassigned taxa
  - Formats ambiguous taxa
  - Returns parsed SILVA taxonomy vector


The following information can be found in the [SILVA-qiime notes file.](https://www.arb-silva.de/no_cache/download/archive/qiime/)


Consensus and Majority Taxonomies
=================================


Reason for these alternative taxonomy string files:

A user of the Silva119 data pointed out that the taxonomy with the SILVA119 release is based only upon the taxonomy string of the representative sequence for the cluster of reads, which could lead to incorrect confidence in taxonomy assignments at the fine level (genus/species). To address this, I have endeavored to create taxonomy strings that are either consensus (all taxa strings must match for every read that fell into the cluster) or majority (greater than or equal to 90% of the taxonomy strings for a given cluster). If a taxonomy string fails to be consensus or majority, then it becomes ambiguous, moving up the levels of taxonomy until consensus/majority taxonomy strings are met.

For example, if a cluster had two reads, and one taxonomy string was:

> D_0__Archaea;D_1__Euryarchaeota;D_2__Methanobacteria;D_3__Methanobacteriales;D_4__Methanobacteriaceae;D_5__Methanobrevibacter;D_6__Methanobrevibacter sp. HW3

and the second taxonomy string was:

> D_0__Archaea;D_1__Euryarchaeota;D_2__Methanobacteria;D_3__Methanobacteriales;D_4__Methanobacteriaceae;D_5__Methanobrevibacter;D_6__Methanobrevibacter smithii

Then for either consensus or majority strings, the level 7 (0 is the first level, the domain) data would become ambiguous, as the species levels do not match. The above string for the representative sequence taxonomy mapping file becomes:

> D_0__Archaea;D_1__Euryarchaeota;D_2__Methanobacteria;D_3__Methanobacteriales;D_4__Methanobacteriaceae;D_5__Methanobrevibacter;Ambiguous_taxa

Because the taxonomy strings are not perfectly matched in terms of names/depths across all  of the SILVA data, this can lead to some taxonomies being more **ambiguous** with my approach (exact string matches) than they actually are, particularly for the eukaryotes. There are over 1.5 million taxonomy strings in the non-redundant SILVA 119 release (even more in later releases), so I canâ€™t fault the maintainers of SILVA for these taxonomy strings being imperfect from a parsing/bioinformatics perspective.

The scripts used to create the consensus and 90% majority taxonomy strings, create_consensus_taxonomy.py and create_majority_taxonomy.py, are located here (the OTU mapping files used with these scripts were generated during the â€œcreation of representative sequence filesâ€ section):
https://gist.github.com/walterst/bd69a19e75748f79efeb
https://gist.github.com/walterst/f6f08f6583bb320bb10d
