### PR TITLE
Add missing whitespace in rarefy_even_depth message

### DIFF
--- a/R/transform_filter-methods.R
+++ b/R/transform_filter-methods.R
@@ -183,7 +183,7 @@ rarefy_even_depth <- function(physeq, sample.size=min(sample_sums(physeq)),
     rmtaxa = taxa_names(newsub)[taxa_sums(newsub) <= 0]
     if( length(rmtaxa) > 0 ){
       if(verbose){
-        message(length(rmtaxa), "OTUs were removed because they are no longer \n",
+        message(length(rmtaxa), " OTUs were removed because they are no longer \n",
             "present in any sample after random subsampling\n")
         message("...")
       }


### PR DESCRIPTION
Hello!
This pull request fixes missing whitespace in `rarefy_even_depth` message (if `verbose == TRUE`).
E.g., it was: `10OTUs were removed ...`
Now it is fixed to `10 OTUs were removed ...`

Thank you for the great package!
With best regards,
Vladimir