### PR TITLE
Fix species richness for non-integer data (e.g., OTU proportions)

### DIFF
--- a/R/extend_vegan.R
+++ b/R/extend_vegan.R
@@ -233,10 +233,13 @@ estimate_richness <- function(physeq, split=TRUE, measures=NULL){
   # Initialize to NULL
   outlist = vector("list")
 	# Some standard diversity indices
-  estimRmeas = c("Chao1", "Observed", "ACE")
-	if( any(estimRmeas %in% measures) ){ 
+  if( "Observed" %in% measures ){
+    outlist <- c(outlist, list(Observed = specnumber(OTU)))
+  }
+  estimRmeas = c("Chao1", "ACE")
+  if( any(estimRmeas %in% measures) ){ 
     outlist <- c(outlist, list(t(data.frame(estimateR(OTU)))))
-	}
+  }
 	if( "Shannon" %in% measures ){
     outlist <- c(outlist, list(shannon = diversity(OTU, index="shannon")))
 	}


### PR DESCRIPTION
Hello!

Currently `estimate_richness(..., measures = "Observed")` works only for integer data:
```
esp <- transform_sample_counts(esophagus, function(OTU) OTU/sum(OTU) )
estimate_richness(esp, measures = "Observed")
```
Leads to an error
```
Error in estimateR.default(newX[, i], ...) : 
  function accepts only integers (counts)
```

I propose to change `estimateR`-function for `vegan::specnumber` which works fine for non-integer data (e.g., OTU proportions).

This commit does not change column names and the order of columns in `estimate_richness` results, so it shouldn't impact any dependent functions.

With best regards,
Vladimir

