### PR TITLE
Add message to tax_glom

### DIFF
--- a/R/transform_filter-methods.R
+++ b/R/transform_filter-methods.R
@@ -407,7 +407,7 @@ tax_glom <- function(physeq, taxrank=rank_names(physeq)[1],
 	# if NArm is TRUE, remove the empty, white-space, NA values from 
 	if( NArm ){
 		keep_species <- names(tax)[ !(tax %in% bad_empty) ]
-		discard_species <- length(names(tax)[(tax %in% bad_empty)])
+		discard_species <- names(tax)[(tax %in% bad_empty)]
 		if(verbose){
 		  if(length(discard_species) > 0){ 
 		  message(c(length(discard_species), " of ", ntaxa(physeq), " OTUs were removed due to lack of taxonomic information"))}}


### PR DESCRIPTION
Hello,

I've been using phyloseq for awhile now, but I'm still relatively new to coding and brand new to github. This is a baby's first pull request. 

I've found the tax_glom function to be useful but a bit dangerous, especially given that the default for NArm is TRUE.

Here I propose to add a simple message describing the number of OTUs lost during agglomeration, similar to the message in rarefy_even_depth.

This is really just me practicing github and learning to code; sorry if this is too trivial / not worthy of a pull request. 

And thank you for the exceptional package! 

Best,
Ian