### PR TITLE
Fix reference to deprecated function

### DIFF
--- a/R/sampleData-class.R
+++ b/R/sampleData-class.R
@@ -122,7 +122,7 @@ reconcile_categories <- function(DFSM){
 #'
 #' @return A subsetted object with the same class as \code{physeq}.
 #' 
-#' @seealso \code{\link{subset_species}}
+#' @seealso \code{\link{subset_taxa}}
 #'
 #' @export
 #' @rdname subset_samples-methods


### PR DESCRIPTION
Update the reference to "subset_species" in the "See Also" section of the docs for `subset_samples()` to refer to "subset_taxa".