### PR TITLE
Update phyloseq_to_metagenomeSeq function

### DIFF
--- a/R/extend_metagenomeSeq.R
+++ b/R/extend_metagenomeSeq.R
@@ -47,7 +47,7 @@ phyloseq_to_metagenomeSeq = function(physeq, ...){
   # Create taxa annotation if possible
   if(!is.null(tax_table(physeq,FALSE))){
     TDF = AnnotatedDataFrame(data.frame(OTUname = taxa_names(physeq),
-          data.frame(tax_table(physeq)),row.names = taxa_names(physeq)))
+          data.frame(tax_table(physeq)@.Data),row.names = taxa_names(physeq)))
   } else {
     TDF = AnnotatedDataFrame(data.frame(OTUname = taxa_names(physeq),
           row.names = taxa_names(physeq)))


### PR DESCRIPTION
This function crashes on line 50 as follows:

> data.frame(tax_table(physeq))
Error in dimnames(x) <- dn : 
  length of 'dimnames' [1] not equal to array extent

The proposed change is to use instead:  
> data.frame(tax_table(physeq)@.Data)