### PR TITLE
Make logo in README smaller for ease of seeing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 <link href="http://joey711.github.com/phyloseq/markdown.css" rel="stylesheet"></link>
 
-# [phyloseq](http://joey711.github.com/phyloseq/)
+# [phyloseq](http://joey711.github.com/phyloseq/) <a href="https://github.com/joey711/phyloseq/"><img src="inst/extdata/phyloseq.png" alt="phyloseq logo image" align="right" height="139"></a>
 
 [![Travis-CI Build Status](https://travis-ci.org/joey711/phyloseq.svg?branch=master)](https://travis-ci.org/joey711/phyloseq)
 
-![phyloseq](inst/extdata/phyloseq.png)
 
 ## Quick Install
 


### PR DESCRIPTION
Here's a preview of what the logo will look like when you resize it with these changes.

https://github.com/erictleung/phyloseq/tree/fix-large-logo-size

![image](https://user-images.githubusercontent.com/2754821/83795979-2156f780-a655-11ea-9cd3-d94f90e5f954.png)
