### PR TITLE
fisher.alpha(x, se=TRUE) is defunct since Dec 2013: can cause error

### DIFF
--- a/R/extend_vegan.R
+++ b/R/extend_vegan.R
@@ -1,5 +1,5 @@
 ################################################################################
-# Define S3 methods for scores (originally defined by vegan-package) 
+# Define S3 methods for scores (originally defined by vegan-package)
 # to work for other ordination results
 # vegan:::scores.default
 ################################################################################
@@ -247,10 +247,10 @@ estimate_richness <- function(physeq, split=TRUE, measures=NULL){
 	  outlist <- c(outlist, list(invsimpson = diversity(OTU, index="invsimpson")))
 	}
 	if( "Fisher" %in% measures ){
-    fisher = tryCatch(fisher.alpha(OTU, se=TRUE), 
+    fisher = tryCatch(fisher.alpha(OTU),
       warning=function(w){
         warning("phyloseq::estimate_richness: Warning in fisher.alpha(). See `?fisher.fit` or ?`fisher.alpha`. Treat fisher results with caution")
-        suppressWarnings(fisher.alpha(OTU, se=TRUE)[, c("alpha", "se")])
+        suppressWarnings(fisher.alpha(OTU))
       }
     )
     if(!is.null(dim(fisher))){


### PR DESCRIPTION
fisherfit/fisher.alpha scrapped se=TRUE in CRAN release vegan
2.0-10 of Dec, 2013. If the underlying routine (uniroot in fisherfit)
issues a warning, estimate_richness will trigger an Error with
Fisher instead of warning. I came across with this in CRAN
package microbial that stopped with error when I changed details
in uniroot bracketing. Discussed in issue #1581.