### PR TITLE
New feature: allow merge_taxa to keep recored of merged (and inextension tax_glom).

### DIFF
--- a/man/merge_taxa-methods.Rd
+++ b/man/merge_taxa-methods.Rd
@@ -46,6 +46,15 @@ if counts are available, or to use \code{1}
 If \code{archetype} is not a valid index or index-name in \code{eqtaxa},
 the first will be used, and the value in archetype will be used 
 as the index-name for the new species.}
+
+\item{multi.fn}{(Optional). Function. Default=NULL. The default is
+to set merged taxa, those with multiple values (usually lower
+taxonomic ranks) to \code{NA}.  This argument allows to apply a
+function to them instead. This argument can help to control
+which or how many values (taxa) have been merged. Example functions
+could be \code{multi.fn=function(x) paste(x, collapse="|")} for
+a string of merged values or \code{length} for the number
+of merged taxa.}
 }
 \value{
 The object, \code{x}, in its original class, but with the specified

--- a/man/tax_glom.Rd
+++ b/man/tax_glom.Rd
@@ -4,7 +4,8 @@
 \alias{tax_glom}
 \title{Agglomerate taxa of the same type.}
 \usage{
-tax_glom(physeq, taxrank=rank_names(physeq)[1], NArm=TRUE, bad_empty=c(NA, "", " ", "\t"))
+tax_glom(physeq, taxrank=rank_names(physeq)[1], NArm=TRUE,
+bad_empty=c(NA, "", " ", "\t"), multi.fn=NULL)
 }
 \arguments{
 \item{physeq}{(Required). \code{\link{phyloseq-class}} or \code{\link{otu_table}}.}
@@ -34,21 +35,34 @@ from the internal agglomeration vector derived from the argument to \code{tax},
 and therefore agglomeration will not combine taxa according to the presence
 of these values in \code{tax}. Furthermore, the corresponding taxa can be
 optionally pruned from the output if \code{NArm} is set to \code{TRUE}.}
+
+\item{multi.fn}{(Optional). Function. Default=NULL. The default is
+to set collapsed taxa, those with lower taxonomic rank than the
+level at which you collapse, to NA. This argument allows to
+apply a function to them instead. While the resulting collapsed
+taxa should be meaningless biologically, this argument can help
+to control which or how many taxa have been
+agglomerated. Example functions could be
+\code{multi.fn=function(x) paste(x, collapse="|")} for a string
+of agglomerated taxa or \code{length} for the number of
+agglomerated taxa.}
 }
 \value{
 A taxonomically-agglomerated, optionally-pruned, object with class matching
 the class of \code{physeq}.
 }
 \description{
-This method merges species that have the same taxonomy at a certain 
-taxonomic rank. 
-Its approach is analogous to \code{\link{tip_glom}}, but uses categorical data
-instead of a tree. In principal, other categorical data known for all taxa
-could also be used in place of taxonomy,
-but for the moment, this must be stored in the \code{taxonomyTable}
-of the data. Also, columns/ranks to the right of the rank chosen to use
-for agglomeration will be replaced with \code{NA},
-because they should be meaningless following agglomeration.
+This method merges species that have the same taxonomy at a certain
+taxonomic rank.  Its approach is analogous to
+\code{\link{tip_glom}}, but uses categorical data instead of a
+tree. In principal, other categorical data known for all taxa could
+also be used in place of taxonomy, but for the moment, this must be
+stored in the \code{taxonomyTable} of the data. Also, columns/ranks
+to the right of the rank chosen to use for agglomeration will be
+replaced with \code{NA} (default), or collapsed (to a string of
+agglomerated taxon annotations). The latter allows control over
+collapsed taxa, which should be meaningless biologically following
+agglomeration.
 }
 \examples{
 # data(GlobalPatterns)


### PR DESCRIPTION
Hi Paul,

are you interested in adding a (tiny) new feature to phyloseq?

I needed something to track what `tax_glom` and `merge_taxa ` are doing and implemented a small feature to allow for a function (mostly relevant for pasting together or counting) to be applied to the length>1 entries of  the merged/agglomerated taxa. 

I exposed the argument I implemented for `merge_taxa` only to `tax_glom`, not to any other of the relevant higher level functions (the only other relevant one would probably be `tip_glom`, I guess). 

I left the default intact, so it should not break anything. I added the required documentation (via `devtools::document()`) and did my best to make sure that  `devtools::check()` complains only about stuff that has nothing to do with my changes. 

Feel free to pull or ignore!

All the best,
Emanuel 

