### PR TITLE
plot_tree: Added ggplot code to fix ugly legend "a"s

### DIFF
--- a/R/plot-methods.R
+++ b/R/plot-methods.R
@@ -2337,7 +2337,7 @@ plot_tree = function(physeq, method="sampledodge", nodelabf=NULL,
       labelMap <- aes_string(x="max(xfartiplab, na.rm=TRUE)", y="y", label=label.tips, color=color)
     }
     # Add labels layer to plotting object.
-    p <- p + geom_text(labelMap, tiplabDT, size=I(text.size), hjust=-0.1, na.rm=TRUE)
+    p <- p + geom_text(labelMap, tiplabDT, size=I(text.size), hjust=-0.1, na.rm=TRUE, show.legend=FALSE) #Added show.legend=FALSE so that the colored "a"s do not appear on legend.
   } 
   # Plot margins. 
   # Adjust the tree graphic plot margins.


### PR DESCRIPTION
When using plot_tree with tip labels and a color, the legend is altered and colored "a"s appear. I tried removing these after executing the plot_tree command but was not able to. Instead I needed to edit the plot_tree function itself to add "show.legend = FALSE" in the final section. 

This removes the geom_text "a" from the legend.

This image shows the "a"s in the legend:
![image](https://github.com/joey711/phyloseq/assets/37250718/044a772f-b6e4-4e81-801b-987477d0f8c2)

Here is what a similar tree looks like with "show.legend=FALSE" added for the tip labels:

![image](https://github.com/joey711/phyloseq/assets/37250718/ae82deb3-0ebc-438f-967f-05f255648484)




p <- p + geom_text(labelMap, tiplabDT, size = I(text.size), 
            hjust = -0.1, na.rm = TRUE, show.legend = FALSE) #added show.legend=FALSE so that the legend does not show colored "a"s when using plot_tree.