### PR TITLE
Add sample name to OTU table for single sample with import_biom()

### DIFF
--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -1784,7 +1784,14 @@ import_biom <- function(BIOMfilename,
   	if (is.null(dim(mat))) {
     	mat <- matrix(mat, ncol = 1)
   	}
- 	colnames(mat) <- colnames(x)
+
+	# Set names from sample_metadata if present
+	if (!is.null(sample_metadata(x))) {
+    	colnames(mat) <- rownames(sample_metadata(x))
+	} else {
+    	colnames(mat) <- colnames(x)
+	}
+	
   	otutab = otu_table(mat, taxa_are_rows = TRUE)
 	argumentlist <- c(argumentlist, list(otutab))
 	

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -1780,8 +1780,12 @@ import_biom <- function(BIOMfilename,
 	########################################
 	# OTU table:
 	########################################
-	otutab = otu_table(as(biom_data(x), "matrix"), taxa_are_rows=TRUE)
-	colnames(otutab) <- colnames(x)
+	mat <- as(biom_data(x), "matrix")
+  	if (is.null(dim(mat))) {
+    	mat <- matrix(mat, ncol = 1)
+  	}
+ 	colnames(mat) <- colnames(x)
+  	otutab = otu_table(mat, taxa_are_rows = TRUE)
 	argumentlist <- c(argumentlist, list(otutab))
 	
 	########################################

--- a/R/IO-methods.R
+++ b/R/IO-methods.R
@@ -1781,6 +1781,7 @@ import_biom <- function(BIOMfilename,
 	# OTU table:
 	########################################
 	otutab = otu_table(as(biom_data(x), "matrix"), taxa_are_rows=TRUE)
+	colnames(otutab) <- colnames(x)
 	argumentlist <- c(argumentlist, list(otutab))
 	
 	########################################


### PR DESCRIPTION
When biom tables contain only one sample, a loss of dimensionality occurs when transforming the OTU table into a matrix that remove the sample name information from the OTU table leading an error due to name inconsistencies with the taxonomy table and sample data.

This fix renames the column of the OTU matrix when only one sample is present in the biom table while using import_biom().